### PR TITLE
Phase 2.2b: StorageService — Score persistence with pruning

### DIFF
--- a/IslamicQuizRamadan.xcodeproj/project.pbxproj
+++ b/IslamicQuizRamadan.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		DDF6898CA0DEE7726C901290 /* Bundle+Decode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDE99E7465718BE65404965 /* Bundle+Decode.swift */; };
 		E8C9857AE97E2735F44372B0 /* QuestionBankTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F583839E370F51176ED373 /* QuestionBankTests.swift */; };
 		EF421FAB2215B85DAAE77656 /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500514CA8ABE76CEEBA0565 /* Question.swift */; };
+		8E4B2C91A5D7F063E8C1B429 /* StorageServiceScoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A7F1E29B4C80D65E1F3A72 /* StorageServiceScoreTests.swift */; };
 		F6ADE6D72D655784B4BADE12 /* StorageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9C79DF260F13883A21FC0D /* StorageServiceTests.swift */; };
 		F72910040F375F861F7F615E /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46D206C8778FE5F3F9312E2 /* StorageService.swift */; };
 		F843BF0E7A8604BFD0EA134B /* IslamicQuizRamadanApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF5AF24343CCA7645DFB369 /* IslamicQuizRamadanApp.swift */; };
@@ -56,6 +57,7 @@
 		59AA14C3C5EEA4772F4F6E53 /* corrupt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = corrupt.json; sourceTree = "<group>"; };
 		5EC20CE11955E31C5867860C /* ScoreRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreRecord.swift; sourceTree = "<group>"; };
 		5F9C79DF260F13883A21FC0D /* StorageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
+		D3A7F1E29B4C80D65E1F3A72 /* StorageServiceScoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceScoreTests.swift; sourceTree = "<group>"; };
 		603B3CDF75D67978A6837242 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		61C6EF5BF171E4CB4D493AE9 /* questions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = questions.json; sourceTree = "<group>"; };
 		677ED83727AD8380CA23D43D /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 			children = (
 				E9F583839E370F51176ED373 /* QuestionBankTests.swift */,
 				70641E32CAE057C6B151BE52 /* QuestionLoaderTests.swift */,
+				D3A7F1E29B4C80D65E1F3A72 /* StorageServiceScoreTests.swift */,
 				5F9C79DF260F13883A21FC0D /* StorageServiceTests.swift */,
 				5E923841AAE6B079E94379B0 /* Fixtures */,
 			);
@@ -319,6 +322,7 @@
 			files = (
 				E8C9857AE97E2735F44372B0 /* QuestionBankTests.swift in Sources */,
 				71C4454C71CDC14316DF4428 /* QuestionLoaderTests.swift in Sources */,
+				8E4B2C91A5D7F063E8C1B429 /* StorageServiceScoreTests.swift in Sources */,
 				F6ADE6D72D655784B4BADE12 /* StorageServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IslamicQuizRamadan/App/AppConstants.swift
+++ b/IslamicQuizRamadan/App/AppConstants.swift
@@ -5,6 +5,7 @@ enum AppConstants {
     static let totalLevels = 10
     static let questionsPerLevel = 10
     static let maxPlayers = 12
+    static let maxScores = 50
     static let maxPlayerNameLength = 20
     static let maxWidth: CGFloat = 600
     static let answerFeedbackDelay: TimeInterval = 1.5

--- a/IslamicQuizRamadan/Services/StorageService.swift
+++ b/IslamicQuizRamadan/Services/StorageService.swift
@@ -58,6 +58,23 @@ struct StorageService {
         return .success(())
     }
 
+    // MARK: - Score Persistence
+
+    func saveScore(_ score: ScoreRecord) {
+        var scores = listScores()
+        scores.append(score)
+        scores.sort(by: >)
+        if scores.count > AppConstants.maxScores {
+            scores = Array(scores.prefix(AppConstants.maxScores))
+        }
+        saveScores(scores)
+    }
+
+    func listScores() -> [ScoreRecord] {
+        guard let data = defaults.data(forKey: Keys.scores) else { return [] }
+        return (try? JSONDecoder().decode([ScoreRecord].self, from: data)) ?? []
+    }
+
     // MARK: - Private
 
     private func savePlayers(_ players: [Player]) {
@@ -66,5 +83,13 @@ struct StorageService {
             return
         }
         defaults.set(data, forKey: Keys.players)
+    }
+
+    private func saveScores(_ scores: [ScoreRecord]) {
+        guard let data = try? JSONEncoder().encode(scores) else {
+            assertionFailure("Failed to encode scores")
+            return
+        }
+        defaults.set(data, forKey: Keys.scores)
     }
 }

--- a/IslamicQuizRamadanTests/StorageServiceScoreTests.swift
+++ b/IslamicQuizRamadanTests/StorageServiceScoreTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import IslamicQuizRamadan
+
+@Suite("StorageService – Score Persistence", .serialized)
+struct StorageServiceScoreTests {
+
+    private let suiteName = "StorageServiceScoreTests"
+
+    private func makeService() -> StorageService {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return StorageService(defaults: defaults)
+    }
+
+    private func makeScore(
+        totalCorrect: Int = 7,
+        completionTimeSeconds: TimeInterval = 120,
+        playerID: UUID = UUID(),
+        playerName: String = "Ahmad"
+    ) -> ScoreRecord {
+        ScoreRecord(
+            playerID: playerID,
+            playerName: playerName,
+            totalCorrect: totalCorrect,
+            completionTimeSeconds: completionTimeSeconds
+        )
+    }
+
+    // MARK: - Save & List
+
+    @Test("Save a score and list returns it")
+    func saveAndList() {
+        let service = makeService()
+        let score = makeScore()
+        service.saveScore(score)
+
+        let scores = service.listScores()
+        #expect(scores.count == 1)
+        #expect(scores[0].id == score.id)
+        #expect(scores[0].totalCorrect == 7)
+    }
+
+    @Test("Save multiple scores and list returns all")
+    func saveMultiple() {
+        let service = makeService()
+        service.saveScore(makeScore(totalCorrect: 5))
+        service.saveScore(makeScore(totalCorrect: 8))
+        service.saveScore(makeScore(totalCorrect: 3))
+
+        let scores = service.listScores()
+        #expect(scores.count == 3)
+    }
+
+    @Test("Scores are returned sorted by rank descending")
+    func sortedByRank() {
+        let service = makeService()
+        service.saveScore(makeScore(totalCorrect: 3, completionTimeSeconds: 100))
+        service.saveScore(makeScore(totalCorrect: 8, completionTimeSeconds: 200))
+        service.saveScore(makeScore(totalCorrect: 8, completionTimeSeconds: 90))
+        service.saveScore(makeScore(totalCorrect: 5, completionTimeSeconds: 60))
+
+        let scores = service.listScores()
+        #expect(scores[0].totalCorrect == 8)
+        #expect(scores[0].completionTimeSeconds == 90)
+        #expect(scores[1].totalCorrect == 8)
+        #expect(scores[1].completionTimeSeconds == 200)
+        #expect(scores[2].totalCorrect == 5)
+        #expect(scores[3].totalCorrect == 3)
+    }
+
+    // MARK: - Pruning
+
+    @Test("Pruning keeps top 50 scores when exceeding limit")
+    func pruningAtLimit() {
+        let service = makeService()
+
+        for i in 1...50 {
+            service.saveScore(makeScore(totalCorrect: i))
+        }
+        #expect(service.listScores().count == 50)
+
+        service.saveScore(makeScore(totalCorrect: 25))
+
+        let scores = service.listScores()
+        #expect(scores.count == 50)
+    }
+
+    @Test("Pruning removes lowest-ranked score")
+    func pruningRemovesLowest() {
+        let service = makeService()
+
+        for i in 1...50 {
+            service.saveScore(makeScore(totalCorrect: i))
+        }
+
+        service.saveScore(makeScore(totalCorrect: 51))
+
+        let scores = service.listScores()
+        #expect(scores.count == 50)
+        #expect(scores.last!.totalCorrect == 2)
+        #expect(scores.first!.totalCorrect == 51)
+    }
+
+    @Test("Pruning uses time as tiebreaker")
+    func pruningTimeTiebreaker() {
+        let service = makeService()
+
+        for i in 1...49 {
+            service.saveScore(makeScore(totalCorrect: 10, completionTimeSeconds: 100))
+        }
+        let slowScore = makeScore(totalCorrect: 10, completionTimeSeconds: 300)
+        service.saveScore(slowScore)
+
+        #expect(service.listScores().count == 50)
+
+        let fastScore = makeScore(totalCorrect: 10, completionTimeSeconds: 50)
+        service.saveScore(fastScore)
+
+        let scores = service.listScores()
+        #expect(scores.count == 50)
+        #expect(!scores.contains(where: { $0.id == slowScore.id }))
+        #expect(scores.contains(where: { $0.id == fastScore.id }))
+    }
+
+    // MARK: - Isolation
+
+    @Test("Tests use isolated UserDefaults")
+    func isolation() {
+        let service = makeService()
+        #expect(service.listScores().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `saveScore(_:)` and `listScores()` methods to `StorageService` using the same UserDefaults/JSONEncoder pattern as player CRUD
- Scores are stored sorted by rank (descending) and pruned to keep only the top 50 entries (`AppConstants.maxScores`)
- Lowest-ranked scores (fewest correct answers, then slowest completion time per `ScoreRecord.Comparable`) are removed first when the limit is exceeded
- Adds `maxScores = 50` constant to `AppConstants`

## Test plan
- [x] Save and list scores (single and multiple)
- [x] Scores returned in rank-sorted order (by totalCorrect desc, then completionTime asc)
- [x] Pruning at 50 entries keeps top scores and removes lowest-ranked
- [x] Pruning uses time as tiebreaker when totalCorrect is equal
- [x] UserDefaults isolation between tests
- [x] All 32 existing tests still pass (no regressions)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)