### PR TITLE
Enforce question text under 120 characters

### DIFF
--- a/IslamicQuizRamadan.xcodeproj/project.pbxproj
+++ b/IslamicQuizRamadan.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7785CDB15DF0CF7398DB1E13 /* valid_questions.json in Resources */ = {isa = PBXBuildFile; fileRef = E3CDE84ABF774DBC36A65313 /* valid_questions.json */; };
 		7DCCE5D3B74313EEAA908AA8 /* ScoreRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC20CE11955E31C5867860C /* ScoreRecord.swift */; };
 		878EBA0C9B69565AEA07FC8E /* invalid_correct_index.json in Resources */ = {isa = PBXBuildFile; fileRef = 8931A2FFE469C34379D4DF93 /* invalid_correct_index.json */; };
+		CC01DDEE22FF33AA44BB5501 /* text_too_long.json in Resources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7089A1B2C3D /* text_too_long.json */; };
 		BB01CCDD11EE22FF33AA0001 /* questions-level-01.json in Resources */ = {isa = PBXBuildFile; fileRef = AA01BBCC11DD22EE33FF0001 /* questions-level-01.json */; };
 		BB01CCDD11EE22FF33AA0002 /* questions-level-02.json in Resources */ = {isa = PBXBuildFile; fileRef = AA01BBCC11DD22EE33FF0002 /* questions-level-02.json */; };
 		BB01CCDD11EE22FF33AA0003 /* questions-level-03.json in Resources */ = {isa = PBXBuildFile; fileRef = AA01BBCC11DD22EE33FF0003 /* questions-level-03.json */; };
@@ -99,6 +100,7 @@
 		D780BD2CF5A83D5B04EC0E1F /* StorageServiceScoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceScoreTests.swift; sourceTree = "<group>"; };
 		DA8B8DFE223EDA8F87C9E27B /* IslamicQuizRamadan.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IslamicQuizRamadan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0F40A75554BBD460CDD7633 /* duplicate_ids.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = duplicate_ids.json; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7089A1B2C3D /* text_too_long.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = text_too_long.json; sourceTree = "<group>"; };
 		E3CDE84ABF774DBC36A65313 /* valid_questions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = valid_questions.json; sourceTree = "<group>"; };
 		E9F583839E370F51176ED373 /* QuestionBankTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionBankTests.swift; sourceTree = "<group>"; };
 		EE1E68CFA48E1A2C1D64245A /* ViewModels */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ViewModels; path = IslamicQuizRamadan/ViewModels; sourceTree = SOURCE_ROOT; };
@@ -199,6 +201,7 @@
 				A621CB5776912245ADD526A7 /* duplicate_options.json */,
 				8931A2FFE469C34379D4DF93 /* invalid_correct_index.json */,
 				4B45270C15383D03A7941903 /* invalid_option_count.json */,
+				F1A2B3C4D5E6F7089A1B2C3D /* text_too_long.json */,
 				E3CDE84ABF774DBC36A65313 /* valid_questions.json */,
 			);
 			path = Fixtures;
@@ -357,6 +360,7 @@
 				6BD2D73285088FAE5E6DC00D /* duplicate_options.json in Resources */,
 				878EBA0C9B69565AEA07FC8E /* invalid_correct_index.json in Resources */,
 				55863A0E2F06A0EEC5862443 /* invalid_option_count.json in Resources */,
+				CC01DDEE22FF33AA44BB5501 /* text_too_long.json in Resources */,
 				7785CDB15DF0CF7398DB1E13 /* valid_questions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IslamicQuizRamadan/Services/QuestionLoadError.swift
+++ b/IslamicQuizRamadan/Services/QuestionLoadError.swift
@@ -7,4 +7,5 @@ enum QuestionLoadError: Error, Equatable {
     case duplicateOptionText(questionID: Int, option: String)
     case duplicateQuestionID(Int)
     case correctOptionIndexOutOfBounds(questionID: Int, index: Int, optionCount: Int)
+    case questionTextTooLong(questionID: Int, length: Int, maxLength: Int)
 }

--- a/IslamicQuizRamadan/Services/QuestionLoader.swift
+++ b/IslamicQuizRamadan/Services/QuestionLoader.swift
@@ -34,6 +34,10 @@ struct QuestionLoader {
                 return .failure(.duplicateQuestionID(q.id))
             }
 
+            guard q.text.count <= 120 else {
+                return .failure(.questionTextTooLong(questionID: q.id, length: q.text.count, maxLength: 120))
+            }
+
             guard q.options.count == 5 else {
                 return .failure(.invalidOptionCount(questionID: q.id, count: q.options.count))
             }

--- a/IslamicQuizRamadanTests/Fixtures/text_too_long.json
+++ b/IslamicQuizRamadanTests/Fixtures/text_too_long.json
@@ -1,0 +1,11 @@
+{
+  "questions": [
+    {
+      "id": 1,
+      "level": 1,
+      "text": "This is an extremely long question text that is designed to exceed the one hundred and twenty character limit for question text validation testing purposes here",
+      "options": ["Alpha", "Bravo", "Charlie", "Delta", "Echo"],
+      "correctOptionIndex": 0
+    }
+  ]
+}

--- a/IslamicQuizRamadanTests/QuestionBankTests.swift
+++ b/IslamicQuizRamadanTests/QuestionBankTests.swift
@@ -42,6 +42,13 @@ struct QuestionBankTests {
         #expect(Set(ids).count == ids.count)
     }
 
+    @Test("All question texts are at most 120 characters")
+    func questionTextLength() {
+        for question in questions {
+            #expect(question.text.count <= 120, "Question \(question.id) text is \(question.text.count) characters")
+        }
+    }
+
     @Test("Levels 1 through 10 each have exactly 10 questions")
     func levelCoverage() {
         let levels = Set(questions.map(\.level))

--- a/IslamicQuizRamadanTests/QuestionLoaderTests.swift
+++ b/IslamicQuizRamadanTests/QuestionLoaderTests.swift
@@ -71,6 +71,16 @@ struct QuestionLoaderTests {
         #expect(error == .fileNotFound("nonexistent.json"))
     }
 
+    @Test("Fails with questionTextTooLong when text exceeds 120 characters")
+    func textTooLong() {
+        let result = QuestionLoader.load(from: testBundle, file: "text_too_long.json")
+        guard case .failure(let error) = result else {
+            Issue.record("Expected failure, got \(result)")
+            return
+        }
+        #expect(error == .questionTextTooLong(questionID: 1, length: 160, maxLength: 120))
+    }
+
     @Test("Fails with decodingFailed for corrupt JSON")
     func corruptJSON() {
         let result = QuestionLoader.load(from: testBundle, file: "corrupt.json")


### PR DESCRIPTION
## Summary
- Added `questionTextTooLong` error case to `QuestionLoadError` for questions exceeding 120 characters
- Added validation in `QuestionLoader.load()` to reject questions with text longer than 120 characters
- Added `text_too_long.json` test fixture (160-char question) and unit test in `QuestionLoaderTests`
- Added bank-level test in `QuestionBankTests` to verify all 100 production questions are within limit

All existing questions are already under 120 characters — this change adds guardrails to catch future violations.

Closes #35

## Test plan
- [x] All 14 question-related tests pass (`QuestionLoaderTests` + `QuestionBankTests`)
- [x] New `textTooLong` test verifies loader rejects questions > 120 chars
- [x] New `questionTextLength` bank test confirms all production questions comply

🤖 Generated with [Claude Code](https://claude.com/claude-code)