### PR TITLE
Fix Quranic reference in Q91 and complete theological review

### DIFF
--- a/IslamicQuizRamadan/Resources/questions-level-10.json
+++ b/IslamicQuizRamadan/Resources/questions-level-10.json
@@ -3,7 +3,7 @@
     {
       "id": 91,
       "level": 10,
-      "text": "According to the Quran (2:185), what is stated as the purpose of fasting in Ramadan?",
+      "text": "According to the Quran (2:183), what is stated as the purpose of fasting in Ramadan?",
       "options": ["To earn rewards", "To feel hunger", "That you may attain taqwa (God-consciousness)", "To lose weight", "To build patience"],
       "correctOptionIndex": 2
     },


### PR DESCRIPTION
## Summary
- Reviewed all 100 questions across 10 levels for theological accuracy per issue #37
- Fixed Q91 (Level 10): Corrected Quranic reference from 2:185 to 2:183 — the verse about taqwa as the purpose of fasting is 2:183, not 2:185 (which is about the Quran being revealed during Ramadan)

## Review Checklist (all passed)
- [x] All answers correct according to mainstream Islamic scholarship
- [x] Question wording is clear and unambiguous
- [x] No controversial or disputed topics presented as fact
- [x] Distractors (wrong options) are plausible but clearly incorrect
- [x] Quranic references are accurate (surah/ayah numbers) — **one fix applied**
- [x] Historical facts (dates, events, names) are correct

## Detailed Review Notes
All 100 questions verified. Key validations:
- Prophets mentioned by name (25) ✅, Musa most frequently mentioned ✅
- Pillars of Islam ordering (Shahada→Salah→Zakat→Sawm→Hajj) ✅
- Ramadan is 9th month, 29-30 days, Laylat al-Qadr in last 10 nights ✅
- Battle of Badr in Ramadan 2 AH ✅, Conquest of Mecca 8 AH ✅
- Quran: 114 surahs, 30 juz, revealed over 23 years ✅
- Al-Kawthar shortest surah ✅, Muhammad mentioned 4 times ✅
- Kaffarah (60 days fasting / 60 poor people) ✅, Fidyah ✅
- Quranic refs: 2:183 (fasting prescribed/taqwa), 2:185 (Quran revealed) ✅

## Test plan
- [x] All 42 existing tests pass
- [x] Question text remains under 120-char limit

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)