### PR TITLE
Add ProgressBarView reusable component

### DIFF
--- a/IslamicQuizRamadan/Views/Components/ProgressBarView.swift
+++ b/IslamicQuizRamadan/Views/Components/ProgressBarView.swift
@@ -31,11 +31,12 @@ struct ProgressBarView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Progress: question \(current) of \(total)")
+        .accessibilityValue("\(current) of \(total)")
     }
 
     private var progress: CGFloat {
         guard total > 0 else { return 0 }
-        return min(CGFloat(current) / CGFloat(total), 1.0)
+        return min(max(CGFloat(current) / CGFloat(total), 0), 1.0)
     }
 
     private var trackColor: Color {


### PR DESCRIPTION
Closes #46

## Summary
- Adds `ProgressBarView` reusable component with configurable `current`/`total` values
- Supports both light (Cream) and dark (Midnight Blue) backgrounds via a `Style` enum (`.onLight` / `.onDark`)
- Uses `AppColors` (gold fill, softTeal/cream track) and `AppFonts` (caption label)
- Rounded corners (16pt) on both the track and fill bar
- Accessibility support with combined element, descriptive label, and `accessibilityValue`
- Progress clamped to `[0, 1]` range to handle negative or overflow inputs
- `#Preview` blocks for both light and dark styles

## Test plan
- [ ] Verify `#Preview("On Light Background")` renders correctly in Xcode
- [ ] Verify `#Preview("On Dark Background")` renders correctly in Xcode
- [ ] Confirm progress bar scales proportionally (e.g., 3/10 = 30% width)
- [ ] Confirm edge cases: 0/10 shows empty bar, 10/10 shows full bar
- [ ] Verify VoiceOver reads "Progress: question N of M"

🤖 Generated with [Claude Code](https://claude.com/claude-code)