### PR TITLE
Force light mode on root view (#49)

### DIFF
--- a/IslamicQuizRamadan/App/IslamicQuizRamadanApp.swift
+++ b/IslamicQuizRamadan/App/IslamicQuizRamadanApp.swift
@@ -5,6 +5,7 @@ struct IslamicQuizRamadanApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(.light)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Apply `.preferredColorScheme(.light)` to the root `ContentView` in `IslamicQuizRamadanApp.swift`
- Ensures consistent appearance with the app's fixed light-mode color palette (Cream backgrounds, Deep Purple text, etc.) regardless of device dark/light mode setting

Closes #49

## Test plan
- [ ] Run app with device in dark mode — verify app displays in light mode
- [ ] Run app with device in light mode — verify no visual change
- [ ] Verify all screens maintain consistent color palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)