### PR TITLE
Add PlayerPickerView for player selection and switching

### DIFF
--- a/IslamicQuizRamadan.xcodeproj/project.pbxproj
+++ b/IslamicQuizRamadan.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		F2E1D0C9B8A706F5E4D3C2B1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F607A8B9C0D1E2 /* AppState.swift */; };
 		E3F2D1C0B9A807F6E5D4C3B2 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F607A8B9C0D1E2F3 /* PlayerViewModel.swift */; };
 		D4E3F2C1B0A908F7E6D5C4B3 /* PlayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F607A8B9C0D1E2F3A4 /* PlayerViewModelTests.swift */; };
+		F7A8B9C0D1E2F3A4B5C6D7E8 /* PlayerPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B9C0D1E2F3A4B5C6D7E8F9 /* PlayerPickerView.swift */; };
 		F843BF0E7A8604BFD0EA134B /* IslamicQuizRamadanApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF5AF24343CCA7645DFB369 /* IslamicQuizRamadanApp.swift */; };
 		F85365E4DB28F0C043BBDF34 /* QuestionLoadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4713D261FF8D35839DBF1 /* QuestionLoadError.swift */; };
 		FB15413491215736129EA574 /* questions-level-08.json in Resources */ = {isa = PBXBuildFile; fileRef = B18092C18CE8774F5545E0B1 /* questions-level-08.json */; };
@@ -119,6 +120,7 @@
 		A1B2C3D4E5F607A8B9C0D1E2 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		B2C3D4E5F607A8B9C0D1E2F3 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
 		C3D4E5F607A8B9C0D1E2F3A4 /* PlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModelTests.swift; sourceTree = "<group>"; };
+		A8B9C0D1E2F3A4B5C6D7E8F9 /* PlayerPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPickerView.swift; sourceTree = "<group>"; };
 		EBCA57613A1EF519C453045F /* questions-level-02.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "questions-level-02.json"; sourceTree = "<group>"; };
 		F775A23004525A49C372EF41 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		FBCC9E677574FAC928F2F35E /* AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColors.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 			isa = PBXGroup;
 			children = (
 				603B3CDF75D67978A6837242 /* LaunchScreen.storyboard */,
+				A8B9C0D1E2F3A4B5C6D7E8F9 /* PlayerPickerView.swift */,
 			);
 			path = Launch;
 			sourceTree = "<group>";
@@ -452,6 +455,7 @@
 				43ECA4E79362840B03BB4D9E /* QuestionLoadErrorView.swift in Sources */,
 				FCFEDE8DFF6C56DDFB7FF98E /* QuestionLoader.swift in Sources */,
 				7DCCE5D3B74313EEAA908AA8 /* ScoreRecord.swift in Sources */,
+				F7A8B9C0D1E2F3A4B5C6D7E8 /* PlayerPickerView.swift in Sources */,
 				E3F2D1C0B9A807F6E5D4C3B2 /* PlayerViewModel.swift in Sources */,
 				E7A3C5F9D1B3274605A8E0F2 /* StarRatingView.swift in Sources */,
 				21AA5EA843ADEC44BE5A05ED /* StorageError.swift in Sources */,

--- a/IslamicQuizRamadan/Views/Launch/PlayerPickerView.swift
+++ b/IslamicQuizRamadan/Views/Launch/PlayerPickerView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct PlayerPickerView: View {
+    enum Mode {
+        case initial
+        case switching
+    }
+
+    let mode: Mode
+    @Bindable var playerViewModel: PlayerViewModel
+    @Binding var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showDeleteAlert = false
+    @State private var playerToDelete: Player?
+
+    var body: some View {
+        ZStack {
+            AppColors.cream
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                IslamicHeaderView(title: "Select Player")
+
+                if playerViewModel.players.isEmpty {
+                    Text("No players yet.")
+                        .font(AppFonts.body)
+                        .foregroundStyle(AppColors.deepPurple)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 12) {
+                            ForEach(playerViewModel.players) { player in
+                                playerRow(player)
+                            }
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(24)
+            .frame(maxWidth: AppConstants.maxWidth)
+        }
+        .alert("Delete Player", isPresented: $showDeleteAlert, presenting: playerToDelete) { player in
+            Button("Delete", role: .destructive) {
+                _ = playerViewModel.deletePlayer(id: player.id)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { player in
+            Text("Are you sure you want to delete \"\(player.name)\"? This will also remove their scores.")
+        }
+        .toolbar {
+            if mode == .switching {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private func playerRow(_ player: Player) -> some View {
+        Button {
+            playerViewModel.currentPlayerID = player.id
+            if mode == .initial {
+                appState = .home
+            } else {
+                dismiss()
+            }
+        } label: {
+            HStack {
+                Text(player.name)
+                    .font(AppFonts.headline)
+                    .foregroundStyle(AppColors.deepPurple)
+
+                Spacer()
+
+                if player.id == playerViewModel.currentPlayerID {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(AppColors.gold)
+                }
+            }
+            .padding()
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        player.id == playerViewModel.currentPlayerID
+                            ? AppColors.gold
+                            : AppColors.softTeal,
+                        lineWidth: player.id == playerViewModel.currentPlayerID ? 2 : 1
+                    )
+            )
+        }
+        .contextMenu {
+            if canDelete(player) {
+                Button("Delete", role: .destructive) {
+                    playerToDelete = player
+                    showDeleteAlert = true
+                }
+            }
+        }
+        .swipeActions(edge: .trailing) {
+            if canDelete(player) {
+                Button("Delete", role: .destructive) {
+                    playerToDelete = player
+                    showDeleteAlert = true
+                }
+            }
+        }
+    }
+
+    private func canDelete(_ player: Player) -> Bool {
+        player.id != playerViewModel.currentPlayerID && playerViewModel.players.count > 1
+    }
+}
+
+#Preview("Initial Mode") {
+    @Previewable @State var appState: AppState = .playerSelection
+    let defaults = UserDefaults(suiteName: "PlayerPickerPreview")!
+    let storage = StorageService(defaults: defaults)
+    let vm = PlayerViewModel(storage: storage)
+    PlayerPickerView(mode: .initial, playerViewModel: vm, appState: $appState)
+}
+
+#Preview("Switching Mode") {
+    @Previewable @State var appState: AppState = .home
+    let defaults = UserDefaults(suiteName: "PlayerPickerSwitchPreview")!
+    let storage = StorageService(defaults: defaults)
+    let vm = PlayerViewModel(storage: storage)
+    NavigationStack {
+        PlayerPickerView(mode: .switching, playerViewModel: vm, appState: $appState)
+    }
+}


### PR DESCRIPTION
## Summary
Closes #56

- **PlayerPickerView** (`Views/Launch/PlayerPickerView.swift`): Player selection/switching view with two modes:
  - `.initial` — full-screen via `appState`, no dismiss; on selection transitions to `.home`
  - `.switching` — presented as sheet with Done button; on selection dismisses
  - Shows list of players with checkmark for current player, gold border highlight
  - Delete via context menu and swipe actions with confirmation alert
  - Delete constraints enforced: current player cannot be deleted; sole player cannot be deleted
  - Uses theme components: `AppColors`, `AppFonts`, `IslamicHeaderView`
  - `#Preview` blocks for both modes

## Test plan
- [x] Build succeeds with no warnings
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)