### PR TITLE
Add animations across quiz UI

### DIFF
--- a/IslamicQuizRamadan/Views/Components/StarRatingView.swift
+++ b/IslamicQuizRamadan/Views/Components/StarRatingView.swift
@@ -2,18 +2,32 @@ import SwiftUI
 
 struct StarRatingView: View {
     let filledCount: Int
+    var animated: Bool = false
 
     private let totalStars = 10
+    @State private var visibleStars = 0
 
     var body: some View {
         HStack(spacing: 4) {
             ForEach(0..<totalStars, id: \.self) { index in
-                Image(systemName: index < clampedCount ? "star.fill" : "star")
-                    .foregroundStyle(index < clampedCount ? AppColors.gold : .gray)
+                let isFilled = animated ? index < visibleStars : index < clampedCount
+                Image(systemName: isFilled ? "star.fill" : "star")
+                    .foregroundStyle(isFilled ? AppColors.gold : .gray)
+                    .scaleEffect(isFilled ? 1.0 : 0.8)
+                    .animation(
+                        .spring(response: 0.3, dampingFraction: 0.6)
+                            .delay(Double(index) * 0.08),
+                        value: visibleStars
+                    )
             }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(clampedCount) out of \(totalStars) stars")
+        .onAppear {
+            if animated {
+                visibleStars = clampedCount
+            }
+        }
     }
 
     private var clampedCount: Int {

--- a/IslamicQuizRamadan/Views/Game/AnswerButtonView.swift
+++ b/IslamicQuizRamadan/Views/Game/AnswerButtonView.swift
@@ -33,6 +33,9 @@ struct AnswerButtonView: View {
             .background(backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: 16))
         }
+        .scaleEffect(answerState == .default ? 1.0 : 0.95)
+        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: answerState)
+        .animation(.easeInOut(duration: 0.3), value: backgroundColor)
         .disabled(answerState != .default)
         .accessibilityLabel(accessibilityText)
     }

--- a/IslamicQuizRamadan/Views/Game/LevelCompleteView.swift
+++ b/IslamicQuizRamadan/Views/Game/LevelCompleteView.swift
@@ -14,7 +14,7 @@ struct LevelCompleteView: View {
             VStack(spacing: 24) {
                 IslamicHeaderView(title: "Level \(level) Complete!")
 
-                StarRatingView(filledCount: levelScore)
+                StarRatingView(filledCount: levelScore, animated: true)
 
                 Text("\(levelScore) of \(AppConstants.questionsPerLevel) correct")
                     .font(AppFonts.body)

--- a/IslamicQuizRamadan/Views/Game/QuizView.swift
+++ b/IslamicQuizRamadan/Views/Game/QuizView.swift
@@ -15,6 +15,8 @@ struct QuizView: View {
 
                 if let question = viewModel.currentQuestion {
                     questionSection(question)
+                        .id(question.id)
+                        .transition(.opacity)
                     answersSection
                 }
 
@@ -22,6 +24,7 @@ struct QuizView: View {
             }
             .padding(24)
             .frame(maxWidth: AppConstants.maxWidth)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.session.currentQuestionIndex)
 
             if case .levelComplete(let levelScore) = viewModel.quizPhase {
                 LevelCompleteView(
@@ -30,8 +33,10 @@ struct QuizView: View {
                     totalLevels: AppConstants.totalLevels,
                     onContinue: { viewModel.advanceToNextLevel() }
                 )
+                .transition(.move(edge: .bottom))
             }
         }
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.quizPhase)
         .onChange(of: scenePhase) { _, newPhase in
             viewModel.scenePhaseChanged(newPhase)
         }


### PR DESCRIPTION
## Summary
Closes #78

Adds polish animations across the quiz UI:
- **Answer button tap**: Scale spring (0.95 → 1.0) + color fade `.easeInOut(duration: 0.3)` on state change
- **Question transition**: `.transition(.opacity)` with `.animation(.easeInOut(duration: 0.2))` via `.id(question.id)`
- **Level complete overlay**: `.transition(.move(edge: .bottom))` with spring animation
- **Star rating**: Staggered fill animation — sequential delay per star (left to right, 0.08s each), opt-in via `animated: Bool` parameter. Used in `LevelCompleteView`

## Test plan
- [x] Build succeeds with no warnings
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)